### PR TITLE
Legacy gene tooltips notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# gene-tooltips
+# gene-tooltips has moved and is now bio-tooltips
 
+> [!CAUTION]
 > **Moved:** This package has moved to [`bio-tooltips`](https://www.npmjs.com/package/bio-tooltips).
 >
 > `gene-tooltips` is retained for legacy use only. New projects should install `bio-tooltips`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # gene-tooltips
 
+> **Moved:** This package has moved to [`bio-tooltips`](https://www.npmjs.com/package/bio-tooltips).
+>
+> `gene-tooltips` is retained for legacy use only. New projects should install `bio-tooltips`.
+
+```bash
+npm install bio-tooltips
+````
+
+```ts
+import { GeneTooltip } from 'bio-tooltips/mygene';
+import { ChemicalTooltip } from 'bio-tooltips/mychem';
+import 'bio-tooltips/style.css';
+```
+
+# Legacy package
+
 A framework-agnostic JavaScript/TypeScript library for displaying interactive gene information tooltips.
 
 ## Context

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gene-tooltips",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gene-tooltips",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "license": "MIT",
       "dependencies": {
         "tom-select": "^2.4.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gene-tooltips",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "A framework-agnostic library for showing gene information as a tooltip",
   "keywords": [
     "genetics",


### PR DESCRIPTION
Moving project to `bio-tooltips`: this adds a notice to the NPM repo.